### PR TITLE
Add cf start redis-example-app to start the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Example:
      $ cf push redis-example-app --no-start
      $ cf create-service p-redis development redis
      $ cf bind-service redis-example-app redis
+     $ cf start redis-example-app
 
 ### Endpoints
 


### PR DESCRIPTION
Add cf start redis-example-app to start the app. CF tells you to restage after binding but
you can't do this becasue the app has yet to be staged.