### PR TITLE
Remove `cf restage` step in Redis-Labs CUPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Example:
      $ cf push redis-example-app --no-start
      $ cf cups redis -p "host, password, port"
      $ cf bind-service redis-example-app redis
-     $ cf restage redis-example-app
      $ cf start redis-example-app
 
 ### Endpoints


### PR DESCRIPTION
Removed `cf restage redis-example-app` step from the Redis-Labs CUPS example. 

The `cf restage` command is unnecessary and results in an error. 
```
> cf restage redis-example-app
Restaging app redis-example-app in org onboarding-org / space onboarding-space as some-user...

Staging app and tracing logs...
App has not finished staging
FAILED
```

Paired with @blgm 