### PR TITLE
removed sentinel api support for master, replicas and failover

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -16,39 +16,6 @@ You can run the following commands to create an instance and bind to it:
   end
 end
 
-get '/master' do
-  value = sentinel_client.get_master_info.to_json
-  if value
-    status 200
-    body value
-  else
-    status 400
-    body 'something went wrong'
-  end
-end
-
-get '/replicas' do
-  value = sentinel_client.get_replicas_info.to_json
-  if value
-    status 200
-    body value
-  else
-    status 400
-    body 'something went wrong'
-  end
-end
-
-get '/failover' do
-  value = sentinel_client.fail_over.to_json
-  if value
-    status 200
-    body value
-  else
-    status 400
-    body 'something went wrong'
-  end
-end
-
 put '/:key' do
   data = params[:data]
   if data
@@ -151,10 +118,6 @@ def redis_client_tls(version='TLSv1')
     end
     @client ||= RedisClient.tls(redis_credentials, version)
   end
-end
-
-def sentinel_client
-  @sentinel_client ||= SentinelClient.new(redis_credentials.fetch("master_name"), redis_credentials.fetch("sentinels").first)
 end
 
 def redis_client

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -2,28 +2,6 @@
 require 'redis'
 require_relative 'redis_tls'
 
-class SentinelClient
-  def initialize(master_name, credentials)
-    @client = Redis.new(
-      host: credentials.fetch("host"),
-      port: credentials.fetch("port"),
-    )
-    @master_name = master_name
-  end
-
-  def get_master_info
-    @client.sentinel("master", @master_name)
-  end
-
-  def get_replicas_info
-    @client.sentinel("replicas", @master_name)
-  end
-
-  def fail_over
-    @client.sentinel("failover", @master_name)
-  end
-end
-
 class RedisClient
   def initialize
   end


### PR DESCRIPTION
This PR includes removal of sentinel client code that was used to fetch master, replicas and perform failover removed from client.rb. It was an api implementation in ruby app which is removed from app.rb